### PR TITLE
Dockerfile: update image with the latest security relases.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu
 
+RUN apt-get update
+RUN apt-get dist-upgrade -yq
 RUN apt-get -qy install wget python-minimal inotify-tools make
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
 
 ENV HOME /data
 ENV WGET wget --no-check-certificate -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu
 
-RUN apt-get update
-RUN apt-get dist-upgrade -yq
-RUN apt-get -qy install wget python-minimal inotify-tools make
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+	apt-get dist-upgrade -yq && \
+	apt-get -qy install wget python-minimal inotify-tools make && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 ENV HOME /data
 ENV WGET wget --no-check-certificate -q


### PR DESCRIPTION
Run apt-get update and apt-get dist-upgrade to install all security updates
on the image.

Clean up afterwards.

It's also needed, because the wihtout it, the ubuntu image can't install inotify-tools
